### PR TITLE
Improve display names and formats

### DIFF
--- a/Uppgift12-Garage20/Models/ParkedVehicle.cs
+++ b/Uppgift12-Garage20/Models/ParkedVehicle.cs
@@ -34,5 +34,13 @@ namespace Uppgift12_Garage20.Models
         [Display(Name = "Arrival Time", ShortName = "Arrived")]
         [DisplayFormat(DataFormatString = "{0:yyyy-MM-dd HH:mm}")]
         public DateTime ArrivalTime { get; init; } = DateTime.Now;
+
+        [Display(Name = "Total Time Parked")]
+        [DisplayFormat(DataFormatString = @"{0:%d} days {0:%h} hours {0:%m} minutes")]
+        public TimeSpan TotalParkingTime { get; private set; }
+
+        [Display(Name = "Total Cost")]
+        [DisplayFormat(DataFormatString = "{0:N0}:-")]
+        public decimal TotalCost { get; private set; }
     }
 }

--- a/Uppgift12-Garage20/Models/ParkedVehicle.cs
+++ b/Uppgift12-Garage20/Models/ParkedVehicle.cs
@@ -1,26 +1,37 @@
-﻿using System.ComponentModel;
+﻿using Microsoft.AspNetCore.Mvc;
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 
 namespace Uppgift12_Garage20.Models
 {
+    [ModelMetadataType(typeof(VehicleModelMetaData))]
     public class ParkedVehicle
     {
         public int ParkedVehicleId { get; set; }
-
-        [DisplayName("Vehicle Type")]
         public VehicleType VehicleType { get; set; }
-
-        [DisplayName("Registration Number")]
-        public string RegistrationNumber { get; set; } = string.Empty;
-
+        public string RegistrationNumber { get; init; } = string.Empty;
         public string Color { get; set; } = string.Empty;
         public string Make { get; set; } = string.Empty;
         public string Model { get; set; } = string.Empty;
+        public int NumberOfWheels { get; set; }
+        public DateTime ArrivalTime { get; init; } = DateTime.Now;
+    }
 
-        [DisplayName("Number Of Wheels")]
+    /* Metadata class: Provides a way to attach the attributes (like Display) to properties
+     * in only one place and then reuse them using ModelMetadataType.
+     */
+    public class VehicleModelMetaData
+    {
+        [Display(Name = "Type of Vehicle", ShortName = "Type")]
+        public VehicleType VehicleType { get; set; }
+
+        [Display(Name = "Registration Number", ShortName = "Reg. No.")]
+        public string RegistrationNumber { get; init; } = string.Empty;
+
+        [Display(Name = "Number of Wheels", ShortName = "Wheels")]
         public int NumberOfWheels { get; set; }
 
-        [DisplayName("Arrival Time")]
+        [Display(Name = "Arrival Time", ShortName = "Arrived")]
         [DisplayFormat(DataFormatString = "{0:yyyy-MM-dd HH:mm}")]
         public DateTime ArrivalTime { get; init; } = DateTime.Now;
     }

--- a/Uppgift12-Garage20/Models/Reciept.cs
+++ b/Uppgift12-Garage20/Models/Reciept.cs
@@ -1,14 +1,21 @@
-﻿using Uppgift12_Garage20.Helpers;
+﻿using Microsoft.AspNetCore.Mvc;
+using System.ComponentModel.DataAnnotations;
+using Uppgift12_Garage20.Helpers;
 
 namespace Uppgift12_Garage20.Models
 {
+    [ModelMetadataType(typeof(VehicleModelMetaData))]
     public class Reciept
     {
         public int ParkedVehicleId { get; set; }
         public string RegistrationNumber { get; set; } = string.Empty;
         public DateTime ArrivalTime { get; set; }
 
+        [Display(Name = "Total Time Parked")]
         public TimeSpan TotalParkingTime { get; private set; }
+
+        [Display(Name = "Total Cost")]
+        [DisplayFormat(DataFormatString = "{0:N0}:-")]
         public decimal TotalCost { get; private set; }
 
         public Reciept(int parkedVehicleId, string registrationNumber, DateTime arrivalTime, decimal pricePerHour)

--- a/Uppgift12-Garage20/Models/Reciept.cs
+++ b/Uppgift12-Garage20/Models/Reciept.cs
@@ -10,12 +10,7 @@ namespace Uppgift12_Garage20.Models
         public int ParkedVehicleId { get; set; }
         public string RegistrationNumber { get; set; } = string.Empty;
         public DateTime ArrivalTime { get; set; }
-
-        [Display(Name = "Total Time Parked")]
         public TimeSpan TotalParkingTime { get; private set; }
-
-        [Display(Name = "Total Cost")]
-        [DisplayFormat(DataFormatString = "{0:N0}:-")]
         public decimal TotalCost { get; private set; }
 
         public Reciept(int parkedVehicleId, string registrationNumber, DateTime arrivalTime, decimal pricePerHour)

--- a/Uppgift12-Garage20/ViewModels/VehicleSummaryViewModel.cs
+++ b/Uppgift12-Garage20/ViewModels/VehicleSummaryViewModel.cs
@@ -1,8 +1,10 @@
-﻿using Uppgift12_Garage20.Helpers;
+﻿using Microsoft.AspNetCore.Mvc;
+using Uppgift12_Garage20.Helpers;
 using Uppgift12_Garage20.Models;
 
 namespace Uppgift12_Garage20.ViewModels
 {
+    [ModelMetadataType(typeof(VehicleModelMetaData))]
     public class VehicleSummaryViewModel
     {
         public int ParkedVehicleId { get; init; }
@@ -10,7 +12,7 @@ namespace Uppgift12_Garage20.ViewModels
         public string RegistrationNumber { get; init; } = string.Empty;
         public DateTime ArrivalTime { get; init; }
 
-        public TimeSpan ParkedTimeAmount =>
+        public TimeSpan TotalParkingTime =>
             HelperFunctions.ParkedTimeAmount(ArrivalTime);
 
         // Empty constructor if still needed somewhere in the future

--- a/Uppgift12-Garage20/Views/ParkedVehicles/Index.cshtml
+++ b/Uppgift12-Garage20/Views/ParkedVehicles/Index.cshtml
@@ -22,7 +22,7 @@
                 @Html.DisplayNameFor(model => model.ArrivalTime)
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.ParkedTimeAmount)
+                @Html.DisplayNameFor(model => model.TotalParkingTime)
             </th>
             <th></th>
         </tr>
@@ -40,7 +40,7 @@
                 @Html.DisplayFor(modelItem => item.ArrivalTime)
             </td>
             <td>
-                @Html.DisplayFor(modelItem => item.ParkedTimeAmount)
+                @Html.DisplayFor(modelItem => item.TotalParkingTime)
             </td>
             <td>
                 <a asp-action="Edit" asp-route-id="@item.ParkedVehicleId">Edit</a> |

--- a/Uppgift12-Garage20/Views/ParkedVehicles/Reciept.cshtml
+++ b/Uppgift12-Garage20/Views/ParkedVehicles/Reciept.cshtml
@@ -28,9 +28,7 @@
             @Html.DisplayNameFor(model => model.TotalParkingTime)
         </dt>
         <dd class="col-sm-10">
-            @Html.DisplayFor(model => model.TotalParkingTime.Days) days
-            @Html.DisplayFor(model => model.TotalParkingTime.Hours) hours
-            @Html.DisplayFor(model => model.TotalParkingTime.Minutes) Minutes
+            @Html.DisplayFor(model => model.TotalParkingTime)
         </dd>
         <dt class="col-sm-2">
             @Html.DisplayNameFor(model => model.TotalCost)


### PR DESCRIPTION
Improve the displayed name and format of several properties. This is done by creating the VehicleModelMetaData class (in ParkedVehicle.cs; should maybe be extracted). The ParkedVehicle, Reciept, and VehicleSummaryViewModel classes inherit these display attributes through the ModelMetadataType attribute.

Note that the custom display format of TotalTimeParked for the Reciept view has been removed; I used it as the basis for the format of this property so the result should be the same.